### PR TITLE
Separate input/output fps to avoid loosing buffered input, fixes #2

### DIFF
--- a/src/gdb.h
+++ b/src/gdb.h
@@ -3,14 +3,19 @@
 
 struct FILE;
 
+struct gdb_session {
+	FILE *rx;
+	FILE *tx;
+};
+
 extern int gdb_debug;
 
 int gdb_hex2bin(void *hex, void *bin, size_t len);
 void gdb_bin2hex(void *bin, void *hex, size_t len);
 
-int gdb_recv(FILE *fp, void *buf, size_t len);
-int gdb_send(FILE *fp, void *buf, size_t len);
+int gdb_recv(struct gdb_session *s, void *buf, size_t len);
+int gdb_send(struct gdb_session *s, void *buf, size_t len);
 
-int gdb_send_iter(FILE *fp, int (*next)(void *ctx), void *ctx);
+int gdb_send_iter(struct gdb_session *s, int (*next)(void *ctx), void *ctx);
 
 #endif	/* _GDB_H */


### PR DESCRIPTION
It is still not clear to me why the original design was problematic.

It doesn't seem like fflush(3) was the culprit, as removing it makes no difference, we still throw away the entire input buffer after each call to write(2). Looking at the fdopen(3) manpage, there are no hints about issues with a read+write fp on a socket.

Accept reality, use a separate Rx and Tx fp, and move on to more important things :)